### PR TITLE
add flag to avoid build failure

### DIFF
--- a/examples/python-web-app/Dockerfile
+++ b/examples/python-web-app/Dockerfile
@@ -7,7 +7,7 @@ COPY devops /app
 
 RUN apt-get update && \
     apt-get install -y python3 python3-pip && \
-    pip install -r requirements.txt && \
+    pip install -r requirements.txt --break-system-packages && \
     cd devops
 
 ENTRYPOINT ["python3"]


### PR DESCRIPTION
@iam-veeramalla ran into an error while building from the dockerfile. It occurred due to usage of pip and apt in same docker file. Adding the flag fixes this problem.

Not recommended in prod environment, its more like a quick fix. Other way would be to create a virtual environment before building.