### PR TITLE
Fix: Corrected Dockerfile path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,11 +252,11 @@ This message shows that your installation appears to be working correctly.
 
 ## Great Job, Now start with the examples folder to write your first Dockerfile and move to the next examples. Happy Learning :)
 
-### Clone this repository and move to example folder
+### Clone this repository and move to examples/first-docker-file folder
 
 ```
 git clone https://github.com/iam-veeramalla/Docker-Zero-to-Hero
-cd  examples
+cd Docker-Zero-to-Hero/examples/first-docker-file
 ```
 
 ### Login to Docker [Create an account with https://hub.docker.com/]


### PR DESCRIPTION
Updates the README to accurately reflect the directory containing the Dockerfile, ensuring users can successfully build their first Docker image.

The Dockerfile is actually located within the /Docker-Zero-to-Hero/examples/first-docker-file subdirectory. This PR corrects the navigation instructions, guiding users to the correct location and ensuring a smooth learning experience.