### PR TITLE
Updated Dockerfile to avoid 'LegacyKeyValueFormat' warning

### DIFF
--- a/examples/first-docker-file/Dockerfile
+++ b/examples/first-docker-file/Dockerfile
@@ -10,7 +10,7 @@ COPY . /app
 RUN apt-get update && apt-get install -y python3 python3-pip
 
 # Set environment variables
-ENV NAME World
+ENV NAME=World
 
 # Run a command to start the application
 CMD ["python3", "app.py"]


### PR DESCRIPTION
1 warning found (use docker --debug to expand): - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 13)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the syntax for setting an environment variable in the Dockerfile. No changes to app functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->